### PR TITLE
Add subchannels to funding wheel

### DIFF
--- a/packages/site/src/components/NetworkBalance.stories.tsx
+++ b/packages/site/src/components/NetworkBalance.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { NetworkBalance, NetworkBalanceProps } from './NetworkBalance';
+import { NetworkBalance, NetworkBalanceProps, VirtualChannelBalanceProps } from './NetworkBalance';
 
 export default {
   title: 'NetworkBalance',
@@ -11,51 +11,87 @@ const Template: ComponentStory<typeof NetworkBalance> = (
   args: NetworkBalanceProps,
 ) => <NetworkBalance {...args} />;
 
-export const EvenStart = Template.bind(this, {
-  myBalanceFree: 10n ** 18n,
-  myBalanceLocked: 0n,
-  theirBalanceFree: 10n ** 18n,
-  theirBalanceLocked: 0n,
+export const Zeros = Template.bind(this, {
+  myBalanceFree: 0n,
+  theirBalanceFree: 0n,
+  lockedBalances: [],
 });
 
-export const Mixed = Template.bind(this, {
-  myBalanceFree: 47n,
-  myBalanceLocked: 5n,
-  theirBalanceFree: 100n,
-  theirBalanceLocked: 11n,
+export const EvenStart = Template.bind(this, {
+  myBalanceFree: 10n ** 18n,
+  theirBalanceFree: 10n ** 18n,
+  lockedBalances: [],
 });
 
 export const ClientStart = Template.bind(this, {
   myBalanceFree: 100n,
-  myBalanceLocked: 0n,
   theirBalanceFree: 0n,
-  theirBalanceLocked: 0n,
+  lockedBalances: [],
 });
 
 export const ClientMid = Template.bind(this, {
   myBalanceFree: 70n,
-  myBalanceLocked: 5n,
   theirBalanceFree: 10n,
-  theirBalanceLocked: 15n,
+  lockedBalances: [],
 });
 
 export const ProviderStart = Template.bind(this, {
   myBalanceFree: 0n,
-  myBalanceLocked: 0n,
   theirBalanceFree: 100n,
-  theirBalanceLocked: 0n,
+  lockedBalances: [],
 });
 
 export const ProviderMid = Template.bind(this, {
   myBalanceFree: 15n,
-  myBalanceLocked: 4n,
   theirBalanceFree: 60n,
-  theirBalanceLocked: 21n,
+  lockedBalances: [],
 });
 
-export const Zeros = Template.bind({
-  myBalanceFree: 0n,
-  myBalanceLocked: 0n,
-  theirBalanceFree: 0n,
-  theirBalanceLocked: 0n,
+export const TwoChannels = Template.bind(this, {
+  myBalanceFree: 47n,
+  theirBalanceFree: 100n,
+  lockedBalances: [
+    {
+      budget: 10n,
+      myPercentage: 0.5,
+    },
+    {
+      budget: 30n,
+      myPercentage: 0.2,
+    },
+  ],
 });
+
+const some = randomChannels(5, 100n);
+
+export const SomeChannels = Template.bind(this, {
+  myBalanceFree: 50n,
+  theirBalanceFree: 100n,
+  lockedBalances: some,
+});
+
+const many = randomChannels(15, 150n);
+
+export const ManyChannels = Template.bind(this, {
+  myBalanceFree: 345n,
+  theirBalanceFree: 123n,
+  lockedBalances: many,
+});
+
+function randomChannels(
+  numChannels: number,
+  budgetCeiling: bigint,
+): VirtualChannelBalanceProps[] {
+  const channels = [];
+  for (let i = 0; i < numChannels; i++) {
+    channels.push(randomChannel(budgetCeiling));
+  }
+  return channels;
+}
+
+function randomChannel(budgetCeiling: bigint): VirtualChannelBalanceProps {
+  return {
+    budget: BigInt(Math.floor(Math.random() * Number(budgetCeiling))),
+    myPercentage: Math.random(),
+  };
+}

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -97,6 +97,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
               label={({ dataEntry }) => prettyPrintWei(myBalanceFree)}
               labelPosition={0}
               segmentsStyle={(idx) => ({ color: 'red' })}
+              startAngle={90 - ((myBalanceFreePercentage / 100) * 360) / 2}
             />
           </td>
           <td className="budget-progress-bars">

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -105,6 +105,13 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
   );
 
   const total = myBalanceFree + theirBalanceFree + lockedTotal;
+  const myTotal =
+    myBalanceFree +
+    sortedVirtualChannels.reduce(
+      (acc, x) =>
+        acc + (x.budget * BigInt(Math.round(100 * x.myPercentage))) / 100n,
+      BigInt(0),
+    );
   let data = [{ title: '0', value: 100, color: 'red' }];
   let myBalanceFreePercentage, theirBalanceFreePercentage;
 
@@ -167,7 +174,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
               })}
               radius={42}
               data={data}
-              label={({ dataEntry }) => prettyPrintWei(myBalanceFree)}
+              label={({ dataEntry }) => prettyPrintWei(myTotal)}
               labelPosition={0}
               segmentsStyle={(idx) => ({ color: 'red' })}
               paddingAngle={data.length > 1 ? 0.5 : 0}

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -132,12 +132,14 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
       });
     }
 
-    console.log(`MyBalanceFreePercentage: ${myBalanceFreePercentage}`);
-
     const firstHalfCutoff = virtualChannelData.length / 2;
 
+    // starting from the "my-balance" on the bottom and moving clockwise:
+
+    // stack the locked channels sorter "high-me" to "low-me" balances to the left
     data.push(...virtualChannelData.slice(0, firstHalfCutoff));
 
+    // then the "capacity" balance on top (their balance)
     if (theirBalanceFreePercentage > 0) {
       data.push({
         title: `Receive capacity: ${prettyPrintWei(theirBalanceFree)}`,
@@ -146,9 +148,8 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
       });
     }
 
+    // and then the locked balances sorted "low-me" to "high-me" to the right of that
     data.push(...virtualChannelData.slice(firstHalfCutoff));
-
-    console.log(`DataLength: ${data.length}`);
   }
   return (
     <table>

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -90,13 +90,7 @@ function sortToExtremes(
 }
 
 export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
-  const {
-    myBalanceFree,
-    // myBalanceLocked,
-    theirBalanceFree,
-    // theirBalanceLocked,
-    lockedBalances,
-  } = props;
+  const { myBalanceFree, theirBalanceFree, lockedBalances } = props;
   const sortedVirtualChannels: VirtualChannelBalanceProps[] =
     sortToExtremes(lockedBalances);
   const lockedTotal = sortedVirtualChannels.reduce(

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -103,7 +103,8 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
     myBalanceFree +
     sortedVirtualChannels.reduce(
       (acc, x) =>
-        acc + (x.budget * BigInt(Math.round(100 * x.myPercentage))) / 100n,
+        acc +
+        (x.budget * BigInt(Math.round(10_000 * x.myPercentage))) / 10_000n,
       BigInt(0),
     );
   let data = [{ title: '0', value: 100, color: 'red' }];

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -153,6 +153,17 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
     // and then the locked balances sorted "low-me" to "high-me" to the right of that
     data.push(...virtualChannelData.slice(firstHalfCutoff));
   }
+
+  // The pie-chart renders the first data point starting 0 degrees (3 o'clock)
+  // and then rotates clockwise. We want the first data point - the user balance,
+  // to sit at the bottom (centered at 12 o'clock).
+  //
+  // we:
+  //   - add 90 degrees to the angle (to start at 6 o'clock instead of 3)
+  //   - subtract half of the angle spanned by the user balance (to center it)
+  const angleOfMyBalance = (myBalanceFreePercentage * 360) / 100;
+  const angleOffset = 90 - angleOfMyBalance / 2;
+
   return (
     <table>
       <tbody>
@@ -173,7 +184,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
               labelPosition={0}
               segmentsStyle={(idx) => ({ color: 'red' })}
               paddingAngle={data.length > 1 ? 0.5 : 0}
-              startAngle={90 - myBalanceFreePercentage * 1.8} // 1.8 = 180 degrees / 100 (percentage)
+              startAngle={angleOffset}
             />
           </td>
           <td className="budget-progress-bars">


### PR DESCRIPTION
PR adds some niceties to the channel wheel:

1. "my" balance is rotated to bottom of wheel, for "filling a bucket" feel
2. locked funds are demarcated by channel (rather than mine, theirs)
  - with a visual indicator of internal balance being toward 'me' or 'them'
  - channels with more 'me' funds are displayed 'lowest', consistent with gravity effect in (1.)

Diff is not very easy to read here :/.