### PR TITLE
Add storybook controls

### DIFF
--- a/packages/site/src/components/NetworkBalance.stories.tsx
+++ b/packages/site/src/components/NetworkBalance.stories.tsx
@@ -14,42 +14,49 @@ const Template: ComponentStory<typeof NetworkBalance> = (
 export const Zeros = Template.bind(this, {
   myBalanceFree: 0n,
   theirBalanceFree: 0n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const EvenStart = Template.bind(this, {
   myBalanceFree: 10n ** 18n,
   theirBalanceFree: 10n ** 18n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const ClientStart = Template.bind(this, {
   myBalanceFree: 100n,
   theirBalanceFree: 0n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const ClientMid = Template.bind(this, {
   myBalanceFree: 70n,
   theirBalanceFree: 10n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const ProviderStart = Template.bind(this, {
   myBalanceFree: 0n,
   theirBalanceFree: 100n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const ProviderMid = Template.bind(this, {
   myBalanceFree: 15n,
   theirBalanceFree: 60n,
+  status: 'running',
   lockedBalances: [],
 });
 
 export const TwoChannels = Template.bind(this, {
   myBalanceFree: 47n,
   theirBalanceFree: 100n,
+  status: 'running',
   lockedBalances: [
     {
       budget: 10n,
@@ -62,20 +69,32 @@ export const TwoChannels = Template.bind(this, {
   ],
 });
 
-const some = randomChannels(5, 100n);
-
 export const SomeChannels = Template.bind(this, {
   myBalanceFree: 50n,
   theirBalanceFree: 100n,
-  lockedBalances: some,
+  status: 'running',
+  lockedBalances: randomChannels(5, 100n),
 });
-
-const many = randomChannels(15, 150n);
 
 export const ManyChannels = Template.bind(this, {
   myBalanceFree: 345n,
   theirBalanceFree: 123n,
-  lockedBalances: many,
+  status: 'running',
+  lockedBalances: randomChannels(15, 150n),
+});
+
+export const UnresponsivePeer = Template.bind(this, {
+  myBalanceFree: 25n,
+  theirBalanceFree: 65n,
+  status: 'unresponsive-peer',
+  lockedBalances: randomChannels(5, 100n),
+});
+
+export const UnderChallenge = Template.bind(this, {
+  myBalanceFree: 83n,
+  theirBalanceFree: 24n,
+  status: 'under-challenge',
+  lockedBalances: randomChannels(5, 100n),
 });
 
 function randomChannels(

--- a/packages/site/src/components/NetworkBalance.stories.tsx
+++ b/packages/site/src/components/NetworkBalance.stories.tsx
@@ -1,101 +1,134 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { NetworkBalance, NetworkBalanceProps, VirtualChannelBalanceProps } from './NetworkBalance';
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  NetworkBalance,
+  NetworkBalanceProps,
+  VirtualChannelBalanceProps,
+} from './NetworkBalance';
 
-export default {
+const meta: Meta<typeof NetworkBalance> = {
   title: 'NetworkBalance',
   component: NetworkBalance,
-} as ComponentMeta<typeof NetworkBalance>;
+};
+export default meta;
 
-const Template: ComponentStory<typeof NetworkBalance> = (
-  args: NetworkBalanceProps,
-) => <NetworkBalance {...args} />;
+type NB = StoryObj<NetworkBalanceProps>;
 
-export const Zeros = Template.bind(this, {
-  myBalanceFree: 0n,
-  theirBalanceFree: 0n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const Controls: NB = {
+  args: {
+    myBalanceFree: 100n,
+    theirBalanceFree: 100n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const EvenStart = Template.bind(this, {
-  myBalanceFree: 10n ** 18n,
-  theirBalanceFree: 10n ** 18n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const Zeros: NB = {
+  args: {
+    myBalanceFree: 0n,
+    theirBalanceFree: 0n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const ClientStart = Template.bind(this, {
-  myBalanceFree: 100n,
-  theirBalanceFree: 0n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const EvenStart: NB = {
+  args: {
+    myBalanceFree: 10n ** 18n,
+    theirBalanceFree: 10n ** 18n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const ClientMid = Template.bind(this, {
-  myBalanceFree: 70n,
-  theirBalanceFree: 10n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const ClientStart: NB = {
+  args: {
+    myBalanceFree: 100n,
+    theirBalanceFree: 0n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const ProviderStart = Template.bind(this, {
-  myBalanceFree: 0n,
-  theirBalanceFree: 100n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const ClientMid: NB = {
+  args: {
+    myBalanceFree: 70n,
+    theirBalanceFree: 10n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const ProviderMid = Template.bind(this, {
-  myBalanceFree: 15n,
-  theirBalanceFree: 60n,
-  status: 'running',
-  lockedBalances: [],
-});
+export const ProviderStart: NB = {
+  args: {
+    myBalanceFree: 0n,
+    theirBalanceFree: 100n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const TwoChannels = Template.bind(this, {
-  myBalanceFree: 47n,
-  theirBalanceFree: 100n,
-  status: 'running',
-  lockedBalances: [
-    {
-      budget: 10n,
-      myPercentage: 0.5,
-    },
-    {
-      budget: 30n,
-      myPercentage: 0.2,
-    },
-  ],
-});
+export const ProviderMid: NB = {
+  args: {
+    myBalanceFree: 15n,
+    theirBalanceFree: 60n,
+    status: 'running',
+    lockedBalances: [],
+  },
+};
 
-export const SomeChannels = Template.bind(this, {
-  myBalanceFree: 50n,
-  theirBalanceFree: 100n,
-  status: 'running',
-  lockedBalances: randomChannels(5, 100n),
-});
+export const TwoChannels: NB = {
+  args: {
+    myBalanceFree: 47n,
+    theirBalanceFree: 100n,
+    status: 'running',
+    lockedBalances: [
+      {
+        budget: 10n,
+        myPercentage: 0.5,
+      },
+      {
+        budget: 30n,
+        myPercentage: 0.2,
+      },
+    ],
+  },
+};
 
-export const ManyChannels = Template.bind(this, {
-  myBalanceFree: 345n,
-  theirBalanceFree: 123n,
-  status: 'running',
-  lockedBalances: randomChannels(15, 150n),
-});
+export const SomeChannels: NB = {
+  args: {
+    myBalanceFree: 50n,
+    theirBalanceFree: 100n,
+    status: 'running',
+    lockedBalances: randomChannels(5, 100n),
+  },
+};
 
-export const UnresponsivePeer = Template.bind(this, {
-  myBalanceFree: 25n,
-  theirBalanceFree: 65n,
-  status: 'unresponsive-peer',
-  lockedBalances: randomChannels(5, 100n),
-});
+export const ManyChannels: NB = {
+  args: {
+    myBalanceFree: 345n,
+    theirBalanceFree: 123n,
+    status: 'running',
+    lockedBalances: randomChannels(15, 150n),
+  },
+};
 
-export const UnderChallenge = Template.bind(this, {
-  myBalanceFree: 83n,
-  theirBalanceFree: 24n,
-  status: 'under-challenge',
-  lockedBalances: randomChannels(5, 100n),
-});
+export const UnresponsivePeer: NB = {
+  args: {
+    myBalanceFree: 25n,
+    theirBalanceFree: 65n,
+    status: 'unresponsive-peer',
+    lockedBalances: randomChannels(5, 100n),
+  },
+};
+
+export const UnderChallenge: NB = {
+  args: {
+    myBalanceFree: 83n,
+    theirBalanceFree: 24n,
+    status: 'under-challenge',
+    lockedBalances: randomChannels(5, 100n),
+  },
+};
 
 function randomChannels(
   numChannels: number,

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -122,7 +122,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
         (x.budget * BigInt(Math.round(10_000 * x.myPercentage))) / 10_000n,
       BigInt(0),
     );
-  let data = [{ title: '0', value: 100, color: 'red' }];
+  let data = [];
   let myBalanceFreePercentage, theirBalanceFreePercentage;
 
   const virtualChannelData = sortedVirtualChannels.map((x) => ({
@@ -167,6 +167,9 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
 
     // and then the locked balances sorted "low-me" to "high-me" to the right of that
     data.push(...virtualChannelData.slice(firstHalfCutoff));
+  } else {
+    // failure case: no received balance information
+    data = [{ title: '0', value: 100, color: 'red' }];
   }
 
   // The pie-chart renders the first data point starting 0 degrees (3 o'clock)

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -172,6 +172,44 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
     data = [{ title: '0', value: 100, color: 'red' }];
   }
 
+  if (props.asTable) {
+    return (
+      <table>
+        <tbody>
+          <tr>
+            <td></td>
+            <td className="budget-progress-bars">
+              <span>Available spend capacity</span>
+              <LinearProgressWithLabel
+                variant="determinate"
+                value={myBalanceFreePercentage ?? 0}
+                label={prettyPrintWei(myBalanceFree)}
+                className={'bar me'}
+              />
+              <span>Available receive capacity</span>
+              <LinearProgressWithLabel
+                variant="determinate"
+                value={theirBalanceFreePercentage ?? 0}
+                label={prettyPrintWei(theirBalanceFree)}
+                className={'bar their'}
+              />
+
+              <span>Locked Capacity</span>
+              <LinearProgressWithLabel
+                variant="determinate"
+                value={
+                  100 - myBalanceFreePercentage - theirBalanceFreePercentage
+                }
+                label={prettyPrintWei(lockedTotal)}
+                className={'bar locked-me'}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+
   // The pie-chart renders the first data point starting 0 degrees (3 o'clock)
   // and then rotates clockwise. We want the first data point - the user balance,
   // to sit at the bottom (centered at 12 o'clock).
@@ -183,55 +221,23 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
   const angleOffset = 90 - angleOfMyBalance / 2;
 
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <PieChart
-              className="budget-pie-chart"
-              animate
-              lineWidth={18}
-              labelStyle={(index) => ({
-                fill: '#ea692b',
-                fontSize: '10px',
-                fontFamily: 'sans-serif',
-              })}
-              radius={42}
-              data={data}
-              label={({ dataEntry }) => prettyPrintWei(myTotal)}
-              labelPosition={0}
-              segmentsStyle={(idx) => ({ color: 'red' })}
-              paddingAngle={data.length > 1 ? 0.5 : 0}
-              startAngle={angleOffset}
-            />
-          </td>
-          <td className="budget-progress-bars">
-            <span>Available spend capacity</span>
-            <LinearProgressWithLabel
-              variant="determinate"
-              value={myBalanceFreePercentage ?? 0}
-              label={prettyPrintWei(myBalanceFree)}
-              className={'bar me'}
-            />
-            <span>Available receive capacity</span>
-            <LinearProgressWithLabel
-              variant="determinate"
-              value={theirBalanceFreePercentage ?? 0}
-              label={prettyPrintWei(theirBalanceFree)}
-              className={'bar their'}
-            />
-
-            <span>Locked Capacity</span>
-            <LinearProgressWithLabel
-              variant="determinate"
-              value={100 - myBalanceFreePercentage - theirBalanceFreePercentage}
-              label={prettyPrintWei(lockedTotal)}
-              className={'bar locked-me'}
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <PieChart
+      className="budget-pie-chart"
+      animate
+      lineWidth={18}
+      labelStyle={(index) => ({
+        fill: color,
+        fontSize: '10px',
+        fontFamily: 'sans-serif',
+      })}
+      radius={42}
+      data={data}
+      label={({ dataEntry }) => prettyPrintWei(myTotal)}
+      labelPosition={0}
+      segmentsStyle={(idx) => ({ color: 'red' })}
+      paddingAngle={data.length > 1 ? 0.5 : 0}
+      startAngle={angleOffset}
+    />
   );
 };
 

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -103,11 +103,11 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
   const color = ((status: NetworkBalanceProps['status']): string => {
     switch (status) {
       case 'running':
-        return '#4caf50'; // mui-green-500 todo: move colors to _variables.scss
+        return styles.cGreen;
       case 'unresponsive-peer':
-        return '#ffa000'; // mui-amber-700
+        return styles.cAmber;
       case 'under-challenge':
-        return '#b71c1c'; // mui-red-900
+        return styles.cRed;
       default:
         return styles.cOrange;
     }

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -18,6 +18,8 @@ BigInt.prototype.toJSON = function (): string {
 };
 
 export type NetworkBalanceProps = {
+  asTable?: boolean;
+  status: 'running' | 'unresponsive-peer' | 'under-challenge';
   myBalanceFree: bigint;
   theirBalanceFree: bigint;
   lockedBalances: VirtualChannelBalanceProps[];
@@ -98,6 +100,19 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
     BigInt(0),
   );
 
+  const color = ((status: NetworkBalanceProps['status']): string => {
+    switch (status) {
+      case 'running':
+        return '#4caf50'; // mui-green-500 todo: move colors to _variables.scss
+      case 'unresponsive-peer':
+        return '#ffa000'; // mui-amber-700
+      case 'under-challenge':
+        return '#b71c1c'; // mui-red-900
+      default:
+        return styles.cOrange;
+    }
+  })(props.status);
+
   const total = myBalanceFree + theirBalanceFree + lockedTotal;
   const myTotal =
     myBalanceFree +
@@ -115,7 +130,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
       x.myPercentage * Number(x.budget),
     )} Mine`,
     value: percentageOfTotal(x.budget, total),
-    color: interpolateColor(styles.cGrey, styles.cOrange, x.myPercentage),
+    color: interpolateColor(styles.cGrey, color, x.myPercentage),
   }));
 
   if (total > 0) {
@@ -130,7 +145,7 @@ export const NetworkBalance: React.FC<NetworkBalanceProps> = (props) => {
       data.push({
         title: `${prettyPrintWei(myBalanceFree)}`,
         value: myBalanceFreePercentage,
-        color: styles.cOrange,
+        color,
       });
     }
 

--- a/packages/site/src/components/_variables.scss
+++ b/packages/site/src/components/_variables.scss
@@ -3,9 +3,15 @@ $c-orange-lite: #ea692b60;
 $c-grey: #d5dbe3;
 $c-grey-lite: #d5dbe360;
 $c-orangealt: #f16721;
+$c-green-500: #4caf50;
+$c-amber-700: #ffa000;
+$c-red-900: #b71c1c;
 :export {
   cOrange: $c-orange;
   cOrangeLite: $c-orange-lite;
   cGreyLite: $c-grey-lite;
   cGrey: $c-grey;
+  cGreen: $c-green-500;
+  cAmber: $c-amber-700;
+  cRed: $c-red-900;
 }

--- a/packages/site/src/components/_variables.scss.d.ts
+++ b/packages/site/src/components/_variables.scss.d.ts
@@ -3,6 +3,9 @@ export type I_globalScss = {
   cOrangeLite: string;
   cGreyLite: string;
   cGrey: string;
+  cGreen: string;
+  cAmber: string;
+  cRed: string;
 };
 
 export const styles: I_globalScss;


### PR DESCRIPTION
Note: PR is stacked on top of #12, which should be merged first.

PR changes the data type of the "story" literals so that controls are enabled during render.

(Controls let you alter component props according to sensible defaults.)

EG:
![image](https://user-images.githubusercontent.com/10780590/230127264-bfd0b92d-82b1-40c1-b1a5-2e479f0211c9.png)
