### PR TITLE
fix accidental emptying of channels array

### DIFF
--- a/packages/site/.eslintrc.js
+++ b/packages/site/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
       files: ['**/*.{ts,tsx}'],
       rules: {
         'jsdoc/require-jsdoc': 0,
+        '@typescript-eslint/prefer-for-of': 0,
       },
     },
   ],

--- a/packages/site/src/components/NetworkBalance.stories.tsx
+++ b/packages/site/src/components/NetworkBalance.stories.tsx
@@ -13,15 +13,6 @@ export default meta;
 
 type NB = StoryObj<NetworkBalanceProps>;
 
-export const Controls: NB = {
-  args: {
-    myBalanceFree: 100n,
-    theirBalanceFree: 100n,
-    status: 'running',
-    lockedBalances: [],
-  },
-};
-
 export const Zeros: NB = {
   args: {
     myBalanceFree: 0n,

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/prefer-for-of */
 import {
   Box,
   LinearProgress,

--- a/packages/site/src/components/NetworkBalance.tsx
+++ b/packages/site/src/components/NetworkBalance.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-for-of */
 import {
   Box,
   LinearProgress,
@@ -70,7 +71,7 @@ function interpolateColor(
 function sortToExtremes(
   channels: VirtualChannelBalanceProps[],
 ): VirtualChannelBalanceProps[] {
-  const sorted = channels.sort((a, b) => b.myPercentage - a.myPercentage);
+  channels.sort((a, b) => a.myPercentage - b.myPercentage);
 
   const toExtremes: VirtualChannelBalanceProps[] = [];
 
@@ -78,12 +79,12 @@ function sortToExtremes(
 
   // from smallest to largest, alternate adding to the left or right of the array
   // End result is smallest in the middle, largest to the outsides
-  while (sorted.length > 0) {
+  for (let i = 0; i < channels.length; i++) {
     if (next === 'l') {
-      toExtremes.unshift(sorted.pop() as VirtualChannelBalanceProps);
+      toExtremes.unshift(channels[i]);
       next = 'r';
     } else {
-      toExtremes.push(sorted.pop() as VirtualChannelBalanceProps);
+      toExtremes.push(channels[i]);
       next = 'l';
     }
   }


### PR DESCRIPTION
NetworkBalance component does some sorting / parsing of its input props to arrange items for a pleasing display.

Previously, this rearranging was done by `pop()`ping items from the array input to props, and constructing a new array for the display.

Bug: after popping all items off of the input prop, subsequent renders would fail (because the input prop was now empty!).

PR changes the filtering function to leave the input prop intact.

PR also removes the non-useful `Controls` story which had been added to test the new story type with controls enabled.