### PR TITLE
Remove MM create-react-act project, add vite, update dependencies

### DIFF
--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -1,12 +1,18 @@
-import { useState } from "react";
-import reactLogo from "./assets/react.svg";
-import viteLogo from "/vite.svg";
-import statechannelsLogo from "./assets/statechannels.svg";
 import "./App.css";
+import reactLogo from "./assets/react.svg";
+import statechannelsLogo from "./assets/statechannels.svg";
 import { NetworkBalance } from "./components/NetworkBalance";
+import viteLogo from "/vite.svg";
 
 function App() {
-  const [count, setCount] = useState(0);
+  let total = BigInt(200);
+  let mine = BigInt(200);
+
+  setInterval(() => {
+    if (mine > BigInt(0)) {
+      mine -= BigInt(1);
+    }
+  }, 1000);
 
   return (
     <>
@@ -26,8 +32,8 @@ function App() {
         <NetworkBalance
           status="running"
           lockedBalances={[]}
-          myBalanceFree={BigInt(50)}
-          theirBalanceFree={BigInt(200)}
+          myBalanceFree={mine}
+          theirBalanceFree={total - mine}
         ></NetworkBalance>
 
         <p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8155,10 +8155,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.7.4:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@^5.0.2:
   version "5.0.4"


### PR DESCRIPTION
PR replaces the create-react-app + webpack tooling, replacing with vite. Storybook remains intact. Changes along the way:

- replaced import of `js-big-decimal` with `js-big-decimal-esm`, which is a temporary workaround for out of date bundling on `js-big-decimal`. Can switch back to mainstream package if https://github.com/royNiladri/js-big-decimal/pull/99 makes it to npm
- replaced sass variable exports with native css module exports.
- removed GH actions that were relevant to MM snap dev